### PR TITLE
Make sure users are authenticated before allowing them to use tickets

### DIFF
--- a/packages/app/src/helpers/auth.ts
+++ b/packages/app/src/helpers/auth.ts
@@ -16,6 +16,4 @@ export const getUserData = async () => {
 	}
 };
 
-export const removeUserData = () => {
-	return AsyncStorage.removeItem('user');
-};
+export const removeUserData = () => AsyncStorage.removeItem('user');


### PR DESCRIPTION
This PR utilizes the biometric authentication setting, to make sure that the users are verified before giving them the permission to use purchased tickets.